### PR TITLE
feat: Add external link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
         <p class="lead">姑射山人，原名：杨某某，硬科技低魔都市小说爱好者。Q群有惊喜：172073109</p>
         <hr>
         <ul class="list-unstyled">
+            <li><a href="https://www.qidian.com/book/1041797816/" class="btn btn-link custom-link">明末乱攀 2025-2</a></li>
             <li><a href="right-hand/index.html" class="btn btn-link custom-link">光明的右手 2024 ~ </a></li>
             <li><a href="reborn98/index.html" class="btn btn-link custom-link">重生98做软件 2022-9-23 ~ 2022-12</a></li>
             <li><a href="hermes/index.html" class="btn btn-link custom-link">赫尔墨斯 2022-7-12 ~ 2022-8-7</a></li>


### PR DESCRIPTION
Adds a new link "明末乱攀 2025-2" to the beginning of the link list on the homepage. The link points to https://www.qidian.com/book/1041797816/.